### PR TITLE
Add Additional Plugins section (for ExtraContexts)

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -23,6 +23,9 @@ export default new Vuex.Store({
       'extension-legacy-api': null,
       'extension-default-assignments': null,
     },
+    additionalPlugins: {
+      extracontexts: null,
+    },
     discordUserCount: null,
     patreonCount: null,
     editor: {
@@ -56,6 +59,8 @@ export default new Vuex.Store({
     downloads: state => state.downloads,
 
     extensions: state => state.extensions,
+
+    additionalPlugins: state => state.additionalPlugins,
 
     discordUserCount: state => state.discordUserCount,
 
@@ -113,6 +118,10 @@ export default new Vuex.Store({
     setExtensions: (state, extensions) => {
       state.extensions = extensions;
     },
+
+    setAdditionalPlugins: (state, additionalPlugins) => {
+      state.additionalPlugins = additionalPlugins;
+    },  
 
     setDiscordUserCount: (state, discordUserCount) => {
       state.discordUserCount = discordUserCount;
@@ -373,6 +382,7 @@ export default new Vuex.Store({
         commit('setVersion', appData.data.version);
         commit('setDownloads', appData.data.downloads);
         commit('setExtensions', appData.data.extensions);
+        commit('setAdditionalPlugins', appData.data.additionalPlugins);
         commit('setDiscordUserCount', appData.data.discordUserCount);
         commit('setPatreonCount', appData.data.patreonCount);
       } catch (error) {

--- a/src/store.js
+++ b/src/store.js
@@ -26,6 +26,10 @@ export default new Vuex.Store({
     additionalPlugins: {
       extracontexts: null,
     },
+    placeholderExpansions: {
+      'luckperms-mvdw-hook': null,
+      'luckperms-papi-expansion': null,
+    },
     discordUserCount: null,
     patreonCount: null,
     editor: {
@@ -61,6 +65,8 @@ export default new Vuex.Store({
     extensions: state => state.extensions,
 
     additionalPlugins: state => state.additionalPlugins,
+
+    placeholderExpansions: state => state.placeholderExpansions,
 
     discordUserCount: state => state.discordUserCount,
 
@@ -121,7 +127,11 @@ export default new Vuex.Store({
 
     setAdditionalPlugins: (state, additionalPlugins) => {
       state.additionalPlugins = additionalPlugins;
-    },  
+    },
+
+    setPlaceholderExpansions: (state, placeholderExpansions) => {
+      state.placeholderExpansions = placeholderExpansions;
+    },
 
     setDiscordUserCount: (state, discordUserCount) => {
       state.discordUserCount = discordUserCount;
@@ -383,6 +393,7 @@ export default new Vuex.Store({
         commit('setDownloads', appData.data.downloads);
         commit('setExtensions', appData.data.extensions);
         commit('setAdditionalPlugins', appData.data.additionalPlugins);
+        commit('setPlaceholderExpansions', appData.data.placeholderExpansions);
         commit('setDiscordUserCount', appData.data.discordUserCount);
         commit('setPatreonCount', appData.data.patreonCount);
       } catch (error) {

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -143,6 +143,30 @@
         </div>
       </section>
     </div>
+    <section class="hero additional-plugins">
+      <div class="container">
+        <div>
+          <h1>Additional Plugins</h1>
+          <p>Additional plugins can provide more complex features, but may not be available on all platforms</p>
+        </div>
+      </div>
+    </section>
+    <div class="container additional-plugins">
+      <section class="resources">
+        <div>
+          <a :href="additionalPlugins['extracontexts']" class="resource">
+            <span>
+              <font-awesome icon="arrow-alt-circle-down" />
+              ExtraContexts Plugin
+            </span>
+            <small>LuckPerms 5.0 and above</small>
+          </a>
+          <div>
+            <p>Add more context, including some for other plugins</p>
+          </div>
+        </div>
+      </section>
+    </div>
 
     <transition name="fade">
       <Quiz v-if="quiz.open" :downloads="downloads" @close="quiz.open = false" />
@@ -168,6 +192,7 @@ export default {
   },
   computed: {
     extensions() { return this.$store.getters.extensions; },
+    additionalPlugins() { return this.$store.getters.additionalPlugins; },
     downloads() { return this.$store.getters.downloads; },
     version() { return this.$store.getters.version; },
   },
@@ -256,7 +281,8 @@ export default {
       }
     }
 
-    .extensions {
+    .extensions,
+    .additional-plugins {
       &.hero {
         .container {
           justify-content: center;
@@ -277,6 +303,12 @@ export default {
             }
           }
         }
+      }
+    }
+
+    .additional-plugins {
+      section {
+        justify-content: center;
       }
     }
   }

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -159,10 +159,46 @@
               <font-awesome icon="arrow-alt-circle-down" />
               ExtraContexts Plugin
             </span>
-            <small>LuckPerms 5.0 and above</small>
+            <small>LuckPerms 5.0 and above, Bukkit only</small>
           </a>
           <div>
             <p>Add more context, including some for other plugins</p>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section class="hero placeholder-expansions">
+      <div class="container">
+        <div>
+          <h1>Placeholder Expansions</h1>
+          <p>LuckPerms adds <router-link to="/wiki/Placeholders#placeholders">placeholders</router-link> to PlaceholderAPI and MVdWPlaceholderAPI</p>
+        </div>
+      </div>
+    </section>
+    <div class="container placeholder-expansions">
+      <section class="resources">
+        <div>
+          <a :href="placeholderExpansions['luckperms-papi-expansion']" class="resource">
+            <span>
+              <font-awesome icon="arrow-alt-circle-down" />
+              PlaceholderAPI
+            </span>
+            <small>LuckPerms 5.0 and above, Bukkit only</small>
+          </a>
+          <div>
+            <p>Install using either <code>/papi ecloud download LuckPerms</code> or by <router-link to="/wiki/Placeholders#manual-install">installing manually</router-link>.</p>
+          </div>
+        </div>
+        <div>
+          <a :href="placeholderExpansions['luckperms-mvdw-hook']" class="resource">
+            <span>
+              <font-awesome icon="arrow-alt-circle-down" />
+              MVdWPlaceholderAPI
+            </span>
+            <small>LuckPerms 5.0 and above, Bukkit only</small>
+          </a>
+          <div>
+            <p>Place the JAR file in your <code>/plugins/</code> folder.</p>
           </div>
         </div>
       </section>
@@ -193,6 +229,7 @@ export default {
   computed: {
     extensions() { return this.$store.getters.extensions; },
     additionalPlugins() { return this.$store.getters.additionalPlugins; },
+    placeholderExpansions() { return this.$store.getters.placeholderExpansions; },
     downloads() { return this.$store.getters.downloads; },
     version() { return this.$store.getters.version; },
   },
@@ -282,7 +319,8 @@ export default {
     }
 
     .extensions,
-    .additional-plugins {
+    .additional-plugins,
+    .placeholder-expansions {
       &.hero {
         .container {
           justify-content: center;

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -109,10 +109,12 @@
                   <Meta :session="currentSession" :sessionData="currentSessionData" />
                   <NodeList :nodes="currentNodes" />
                 </div>
-                <AddNode />
               </div>
             </transition>
 
+            <transition name="fade">
+              <AddNode v-if="currentSession" />
+            </transition>
           </div>
         </div>
       </transition>


### PR DESCRIPTION
**Please don't merge until LuckPerms/metadata-api#1 is merged**

Adds additional plugins section, just ExtraContexts at the moment, but if more should come we can add them to that too.
Because it's the only one it's centered.

## How it looks like
![image](https://user-images.githubusercontent.com/43016900/86343739-a71c9180-bc59-11ea-981a-9ee12a58a44e.png)
