### PR TITLE
Use i18n locale instead of local lang for date

### DIFF
--- a/src/components/Editor/Node.vue
+++ b/src/components/Editor/Node.vue
@@ -222,7 +222,7 @@ export default {
       return context.values;
     },
     relativeExpiry() {
-      return relativeDate(this.source.expiry);
+      return relativeDate(this.source.expiry, this.$i18n.locale);
     },
   },
   methods: {

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -2,7 +2,7 @@
  * Compares dates and returns the relative
  *
  * @param {number} date - The timestamp being compared
- * @param {string} language - The language in which the time should be returned
+ * @param {string} language - The language in which the date/time should be returned
  * @param {number} [baseDate] - The timestamp being compared from (defaults to now)
  * @param {boolean} [includeTime=false] - Whether to include return the time
  * @returns {String}

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -2,13 +2,14 @@
  * Compares dates and returns the relative
  *
  * @param {number} date - The timestamp being compared
+ * @param {string} language - The language in which the time should be returned
  * @param {number} [baseDate] - The timestamp being compared from (defaults to now)
  * @param {boolean} [includeTime=false] - Whether to include return the time
  * @returns {String}
  */
 // eslint-disable-next-line import/prefer-default-export
-export function relativeDate(date, baseDate, includeTime) {
-  const rtf = new Intl.RelativeTimeFormat(navigator.language, {
+export function relativeDate(date, language, baseDate, includeTime) {
+  const rtf = new Intl.RelativeTimeFormat(language, {
     numeric: 'auto',
   });
   const now = baseDate || new Date().getTime();
@@ -47,7 +48,7 @@ export function relativeDate(date, baseDate, includeTime) {
   const dateFormat = rtf.format(value, unit);
 
   if (includeTime) {
-    const dateTime = new Intl.DateTimeFormat(navigator.language, {
+    const dateTime = new Intl.DateTimeFormat(language, {
       hour: 'numeric',
       minute: 'numeric',
       second: 'numeric',

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -308,7 +308,7 @@ export default {
     versionTimestamp() { return this.$store.getters.versionTimestamp; },
     relativeTimestamp() {
       if (this.versionTimestamp) {
-        return relativeDate(this.versionTimestamp, new Date().getTime(), true);
+        return relativeDate(this.versionTimestamp, this.$i18n.locale, new Date().getTime(), true);
       }
       return null;
     },
@@ -326,7 +326,7 @@ export default {
       this.quiz.open = false;
     },
     relativeDate(value) {
-      return relativeDate(value);
+      return relativeDate(value, this.$i18n.locale);
     },
   },
 };


### PR DESCRIPTION
We should use the selected language to display the datetime. It appears that not just the time format is returned in the client language, but also the words surrounding it like "ago", leading to situations such as "Latest, built vor 2 Wochen @ ......" ("vor 2 Wochen" is German for "2 weeks ago").
Since, should there be multiple languages translated, users can select their own language, we can just use what they have selected and render the date in that language to make the whole website in the same language.