### PR TITLE
check reversed

### DIFF
--- a/src/components/Download/Quiz.vue
+++ b/src/components/Download/Quiz.vue
@@ -90,8 +90,8 @@
             </div>
           </template>
           <template v-if="options.unsupported">
-            <h1 v-if="options.bungee">{{ $t('quiz.outdated', { serverType }) }}</h1>
-            <h1 v-if="!options.bungee">{{ $t('quiz.travertine') }}</h1>
+            <h1 v-if="!options.bungee">{{ $t('quiz.outdated', { serverType }) }}</h1>
+            <h1 v-if="options.bungee">{{ $t('quiz.travertine') }}</h1>
           </template>
         </div>
       </transition>


### PR DESCRIPTION
I think it makes more sense that way. Because when you use Bukkit you shouldn't switch to Travertine.