### PR TITLE
- Fix verbose display to keep state

### DIFF
--- a/src/components/Verbose/Node.vue
+++ b/src/components/Verbose/Node.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="node">
-    <div class="main" @click="open = !open">
+    <div class="main" @click="onChange">
       <span class="name">
         <avatar
           v-if="source.who.uuid && source.who.uuid !== '00000000-0000-0000-0000-000000000000'"
@@ -25,7 +25,7 @@
             <tr v-if="source.context.length">
               <td>{{ $t('verbose.context') }}</td>
               <td>
-                <code v-for="context in source.context" v-bind:key="context">
+                <code v-for="context in source.context" v-bind:key="context.key">
                   {{ context.key }}: {{ context.value }}
                 </code>
               </td>
@@ -68,6 +68,7 @@
 <script>
 import Avatar from '../Avatar.vue';
 
+
 export default {
   components: {
     Avatar,
@@ -77,8 +78,14 @@ export default {
   },
   data() {
     return {
-      open: false,
+      open: this.source._isOpen,
     };
+  },
+  methods: {
+    onChange() {
+      this.source._isOpen = !this.source._isOpen;
+      this.open = this.source._isOpen;
+    }
   },
   computed: {
     valueIcon() {

--- a/src/components/Wiki/Article.vue
+++ b/src/components/Wiki/Article.vue
@@ -108,7 +108,7 @@ export default {
       } else {
         document.getElementById('article').scrollTo({
           top: 0,
-          behavior: 'smooth',
+          behavior: 'smooth', 
         });
       }
       this.getArticle();

--- a/src/views/Verbose.vue
+++ b/src/views/Verbose.vue
@@ -78,8 +78,8 @@
           :data-sources="filteredNodes"
           data-key="id"
           :data-component="Node"
-          :keeps="50"
           class="data"
+          :keeps="50"
           :estimate-size="38"
         />
       </div>
@@ -144,7 +144,14 @@ import Node from '../components/Verbose/Node.vue';
 import Avatar from '../components/Avatar.vue';
 import updateSession from '@/util/session';
 
-export default {
+function injectOpenStateProperty(sourceData){
+  for(let i=0; i<sourceData.data?.length || 0; i++){
+    sourceData.data[i]._isOpen = false;
+  }
+  return sourceData;
+}
+
+export default {  
   metaInfo: {
     title: 'Verbose',
   },
@@ -159,7 +166,7 @@ export default {
   },
   computed: {
     Node() { return Node; },
-    verboseData() { return this.$store.getters.verbose; },
+    verboseData() { return injectOpenStateProperty( this.$store.getters.verbose ); },
     filteredNodes() {
       const { data } = this.verboseData;
       if (!this.filter) return data;
@@ -175,7 +182,6 @@ export default {
   },
   created() {
     if (this.verboseData?.sessionId) return;
-
     updateSession(this.$route, 'getVerboseData');
   },
   watch: {


### PR DESCRIPTION
I noticed not long ago that on the verbose view page, items would collapse on scroll. I do see that there was a limit set for performance reasons. I added a state tracker to keep the expanded node tabs open. 