### PR TITLE
Algolia DocSearch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "luckperms-web",
       "version": "2.0.1",
       "dependencies": {
+        "@docsearch/css": "^3.3.3",
+        "@docsearch/js": "^3.3.3",
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@fortawesome/free-brands-svg-icons": "^5.12.0",
         "@fortawesome/free-solid-svg-icons": "^5.12.0",
@@ -62,6 +64,146 @@
       },
       "engines": {
         "node": ">12 <17"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
+      "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.4"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
+      "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.4"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
+      "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
+      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+      "dependencies": {
+        "@algolia/cache-common": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
+      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
+      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+      "dependencies": {
+        "@algolia/cache-common": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
+      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
+      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
+      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
+      "dependencies": {
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
+      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
+      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+      "dependencies": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
+      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
+      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+      "dependencies": {
+        "@algolia/logger-common": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
+      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+      "dependencies": {
+        "@algolia/requester-common": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
+      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
+      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.14.3"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
+      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+      "dependencies": {
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1153,6 +1295,47 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "node_modules/@docsearch/css": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.3.3.tgz",
+      "integrity": "sha512-2xAv2GFuHzzmG0SSZgf8wHX0qZX8n9Y1ZirKUk5Wrdc+vH9CL837x2hZIUdwcPZI9caBA+/CzxsS68O4waYjUQ==",
+      "dependencies": {
+        "@docsearch/react": "3.3.3",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.7.4",
+        "@algolia/autocomplete-preset-algolia": "1.7.4",
+        "@docsearch/css": "3.3.3",
+        "algoliasearch": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
@@ -2073,6 +2256,27 @@
       "dev": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
+      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.14.3",
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/cache-in-memory": "4.14.3",
+        "@algolia/client-account": "4.14.3",
+        "@algolia/client-analytics": "4.14.3",
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-personalization": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/logger-console": "4.14.3",
+        "@algolia/requester-browser-xhr": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/requester-node-http": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "node_modules/alphanum-sort": {
@@ -4220,7 +4424,7 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "hasInstallScript": true
     },
     "node_modules/core-util-is": {
@@ -11660,6 +11864,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/preact": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.0.tgz",
+      "integrity": "sha512-ERdIdUpR6doqdaSIh80hvzebHB7O6JxycOhyzAeLEchqOq/4yueslQbfnPwXaNhAYacFTyCclhwkEbOumT0tHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -13139,7 +13352,8 @@
     "node_modules/shvl": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.3.tgz",
-      "integrity": "sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw=="
+      "integrity": "sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==",
+      "deprecated": "older versions vulnerable to prototype pollution"
     },
     "node_modules/signal-exit": {
       "version": "3.0.2",
@@ -13458,7 +13672,8 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
     "node_modules/spdx-correct": {
       "version": "3.1.0",
@@ -13592,6 +13807,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
       "dev": true
     },
     "node_modules/stackframe": {
@@ -16153,6 +16369,142 @@
     }
   },
   "dependencies": {
+    "@algolia/autocomplete-core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
+      "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.7.4"
+      }
+    },
+    "@algolia/autocomplete-preset-algolia": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
+      "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.7.4"
+      }
+    },
+    "@algolia/autocomplete-shared": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
+      "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+    },
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
+      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+      "requires": {
+        "@algolia/cache-common": "4.14.3"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
+      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
+      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+      "requires": {
+        "@algolia/cache-common": "4.14.3"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
+      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+      "requires": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
+      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+      "requires": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
+      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
+      "requires": {
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "@algolia/client-personalization": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
+      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+      "requires": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
+      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+      "requires": {
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
+      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+    },
+    "@algolia/logger-console": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
+      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+      "requires": {
+        "@algolia/logger-common": "4.14.3"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
+      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+      "requires": {
+        "@algolia/requester-common": "4.14.3"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
+      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
+      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+      "requires": {
+        "@algolia/requester-common": "4.14.3"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
+      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+      "requires": {
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -17083,6 +17435,31 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@docsearch/css": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
+    },
+    "@docsearch/js": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.3.3.tgz",
+      "integrity": "sha512-2xAv2GFuHzzmG0SSZgf8wHX0qZX8n9Y1ZirKUk5Wrdc+vH9CL837x2hZIUdwcPZI9caBA+/CzxsS68O4waYjUQ==",
+      "requires": {
+        "@docsearch/react": "3.3.3",
+        "preact": "^10.0.0"
+      }
+    },
+    "@docsearch/react": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
+      "requires": {
+        "@algolia/autocomplete-core": "1.7.4",
+        "@algolia/autocomplete-preset-algolia": "1.7.4",
+        "@docsearch/css": "3.3.3",
+        "algoliasearch": "^4.0.0"
+      }
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
@@ -17864,6 +18241,27 @@
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
       "dev": true,
       "requires": {}
+    },
+    "algoliasearch": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
+      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+      "requires": {
+        "@algolia/cache-browser-local-storage": "4.14.3",
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/cache-in-memory": "4.14.3",
+        "@algolia/client-account": "4.14.3",
+        "@algolia/client-analytics": "4.14.3",
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-personalization": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/logger-console": "4.14.3",
+        "@algolia/requester-browser-xhr": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/requester-node-http": "4.14.3",
+        "@algolia/transporter": "4.14.3"
+      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -25752,6 +26150,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
+    },
+    "preact": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.0.tgz",
+      "integrity": "sha512-ERdIdUpR6doqdaSIh80hvzebHB7O6JxycOhyzAeLEchqOq/4yueslQbfnPwXaNhAYacFTyCclhwkEbOumT0tHw=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@docsearch/css": "^3.3.3",
+    "@docsearch/js": "^3.3.3",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-brands-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,10 @@
       </div>
 
       <ul :class="{ active: menu, 'top-level': true }">
-        <li class="search-container">
+        <li
+          v-show="showSearchBar"
+          class="search-container"
+        >
           <div id="docsearch"></div>
         </li>
         <template v-if="!config.selfHosted">
@@ -196,6 +199,12 @@ export default {
     },
     config() {
       return this.$store.getters.config;
+    },
+    showSearchBar() {
+      // the editor has 2 search bars, lets not add another one :)
+      const routes = ['editor', 'editor-home'];
+
+      return !routes.includes(this.$route.name);
     },
     isToolsRoute() {
       return [

--- a/src/App.vue
+++ b/src/App.vue
@@ -245,7 +245,7 @@ export default {
 :root {
   --docsearch-footer-background: #{$grey};
   --docsearch-footer-shadow: unset;
-  --docsearch-highlight-color: #{$brand-color};
+  --docsearch-highlight-color: rgba(255, 255, 255, .25);
   --docsearch-hit-background: #{$grey};
   --docsearch-hit-color: white;
   --docsearch-hit-shadow: unset;
@@ -758,5 +758,16 @@ body {
 .DocSearch-Logo svg .cls-1,
 .DocSearch-Logo svg .cls-2 {
   fill: var(--docsearch-logo-color);
+}
+
+.DocSearch-Hits,
+.DocSearch-Hit[aria-selected=true] {
+  mark {
+    color: var(--docsearch-logo-color)!important;
+  }
+}
+
+.DocSearch-Footer {
+  border-radius: 0;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -249,6 +249,19 @@ export default {
 @import './scss/variables';
 
 :root {
+  --docsearch-footer-background: #{$grey};
+  --docsearch-footer-shadow: unset;
+  --docsearch-highlight-color: #{$brand-color};
+  --docsearch-hit-background: #{$grey};
+  --docsearch-hit-color: white;
+  --docsearch-hit-shadow: unset;
+  --docsearch-icon-color: rgba(255, 255, 255, .5);
+  --docsearch-key-gradient: linear-gradient(-225deg, #666, #999);
+  --docsearch-key-shadow: inset 0 -2px 0 0 #aaa, inset 0 0 1px 1px #aaa, 0 1px 2px 1px #{$navy};
+  --docsearch-logo-color: #{$brand-color};
+  --docsearch-modal-background: #{$navy};
+  --docsearch-modal-shadow: inset 1px 1px 0 0 #{$navy},0 3px 8px 0 #{$grey};
+  --docsearch-muted-color: rgba(255, 255, 255, .5);
   --docsearch-searchbox-background: #{$grey};
   --docsearch-searchbox-focus-background: #{$grey};
   --docsearch-searchbox-shadow: inset 0 0 0 2px #{$brand-color};
@@ -728,5 +741,19 @@ body {
   padding: 0;
   border-radius: 0;
   font-family: inherit;
+}
+
+.DocSearch-Modal {
+  border-radius: 0;
+  font-family: "Source Sans Pro", sans-serif;
+}
+
+.DocSearch-Input:focus {
+  outline: none;
+}
+
+.DocSearch-Logo svg .cls-1,
+.DocSearch-Logo svg .cls-2 {
+  fill: var(--docsearch-logo-color);
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,9 @@
 
       <ul :class="{ active: menu, 'top-level': true }">
         <li>
+          <div id="docsearch"></div>
+        </li>
+        <li>
           <router-link to="/">
             <font-awesome icon="home" fixed-width />
             {{ $t('links.home') }}
@@ -142,6 +145,9 @@
 </template>
 
 <script>
+import '@docsearch/css';
+import docsearch from '@docsearch/js';
+
 export default {
   metaInfo: {
     titleTemplate: '%s | LuckPerms',
@@ -213,6 +219,15 @@ export default {
 
   created() {
     this.$store.dispatch('getAppData');
+  },
+
+  mounted() {
+    docsearch({
+      container: '#docsearch',
+      appId: 'ZXKCPO8F1T',
+      indexName: 'luckperms',
+      apiKey: 'a37e3bc32993f2eb764d0c84dbd526e9',
+    });
   },
 
   methods: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -537,7 +537,7 @@ body {
           }
         }
 
-        svg {
+        > svg {
           margin-right: .5rem;
           opacity: .5;
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,12 +21,6 @@
         <li class="search-container">
           <div id="docsearch"></div>
         </li>
-        <li>
-          <router-link to="/">
-            <font-awesome icon="home" fixed-width />
-            {{ $t('links.home') }}
-          </router-link>
-        </li>
         <template v-if="!config.selfHosted">
           <li>
             <router-link to="/download">
@@ -438,7 +432,7 @@ body {
       text-decoration: none;
       display: flex;
       align-items: center;
-      font-size: .8rem;
+      font-size: .75rem;
     }
 
     &:hover {
@@ -458,7 +452,7 @@ body {
     background: black;
     right: -100%;
     width: 100%;
-    max-width: 20rem;
+    max-width: 24rem;
     z-index: 100;
     overflow: hidden;
     overflow-y: scroll;
@@ -513,7 +507,7 @@ body {
         display: flex;
         align-items: center;
         font-weight: bold;
-        padding: .5em 1em;
+        padding: .5em;
         text-decoration: none;
         text-transform: uppercase;
         transition: all .2s;
@@ -523,6 +517,11 @@ body {
 
         @include breakpoint($sm) {
           font-size: 1rem;
+
+        }
+
+        @include breakpoint($lg) {
+          padding: .5em 1rem;
         }
 
         &.router-link-exact-active {
@@ -655,11 +654,15 @@ body {
         }
 
         a {
-          padding: 0 1rem;
+          padding: 0 .5rem;
 
           @include breakpoint($sm) {
-            padding: .5rem 1rem;
+
             font-size: 1.5rem;
+          }
+
+          @include breakpoint($lg) {
+            padding: .5rem 1rem;
           }
 
           &.github {
@@ -685,7 +688,7 @@ body {
         all: unset;
         display: flex;
         align-items: center;
-        margin-right: 1rem;
+        margin-right: .5rem;
       }
     }
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
       </div>
 
       <ul :class="{ active: menu, 'top-level': true }">
-        <li>
+        <li class="search-container">
           <div id="docsearch"></div>
         </li>
         <li>
@@ -145,6 +145,7 @@
 </template>
 
 <script>
+// eslint-disable-next-line import/extensions
 import '@docsearch/css';
 import docsearch from '@docsearch/js';
 
@@ -245,6 +246,15 @@ export default {
 </script>
 
 <style lang="scss">
+@import './scss/variables';
+
+:root {
+  --docsearch-searchbox-background: #{$grey};
+  --docsearch-searchbox-focus-background: #{$grey};
+  --docsearch-searchbox-shadow: inset 0 0 0 2px #{$brand-color};
+  --docsearch-text-color: white;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -657,6 +667,13 @@ body {
           }
         }
       }
+
+      &.search-container {
+        all: unset;
+        display: flex;
+        align-items: center;
+        margin-right: 1rem;
+      }
     }
   }
 }
@@ -705,5 +722,11 @@ body {
       opacity: .3;
     }
   }
+}
+
+.DocSearch-Button {
+  padding: 0;
+  border-radius: 0;
+  font-family: inherit;
 }
 </style>


### PR DESCRIPTION
- Adds a search bar powered by Algolia DocSearch.
- Removes the Home button from the navigation, as it was redundant (users can click the LuckPerms logo to go to the home page) and took up too much room with the search bar present.
- Adjusts some styling of the nav bar to make it more responsive.

![image](https://github.com/LuckPerms/LuckPermsWeb/assets/10846855/7d86d51e-8996-4947-b3cd-3298dcc22ce4)
![image](https://github.com/LuckPerms/LuckPermsWeb/assets/10846855/102881ed-edb1-4299-9cb0-d83891c49070)



- [x] need to fix responsiveness
- [x] fix shortcut display on Windows