### PR TITLE
replace all spaces in group/track names and not just the first one

### DIFF
--- a/src/components/Editor/Modals/CreateGroup.vue
+++ b/src/components/Editor/Modals/CreateGroup.vue
@@ -66,7 +66,7 @@ export default {
   },
   methods: {
     updateGroupName(event) {
-      this.group.name = event.target.value.toLowerCase().replace(' ', '-');
+      this.group.name = event.target.value.toLowerCase().replace(/ /g, '-');
     },
 
     addGroup() {

--- a/src/components/Editor/Modals/CreateTrack.vue
+++ b/src/components/Editor/Modals/CreateTrack.vue
@@ -109,7 +109,7 @@ export default {
 
   methods: {
     updateTrackName(event) {
-      this.track.id = event.target.value.toLowerCase().replace(' ', '-');
+      this.track.id = event.target.value.toLowerCase().replace(/ /g, '-');
     },
 
     addTrack() {


### PR DESCRIPTION
fixes LuckPerms/LuckPerms#3865

`String.prototype.replace()` in JavaScript only replaces the first occurrence when the first argument provided is a string. If text with multiple spaces was pasted into the box, only the first one would get replaced. This PR replaces the `" "` with a global regex `/ /g` so all occurrences will get replaced.